### PR TITLE
Allow to set header for apexrest function.

### DIFF
--- a/forcetk.js
+++ b/forcetk.js
@@ -250,6 +250,7 @@ if (forcetk.Client === undefined) {
      * @param [method="GET"] HTTP method for call
      * @param [payload=null] payload for POST/PATCH etc
 	 * @param [paramMap={}] parameters to send as header values for POST/PATCH etc
+	 * @param [retry] specifies whether to retry on error
      */
     forcetk.Client.prototype.apexrest = function(path, callback, error, method, payload, paramMap, retry) {
         var that = this;
@@ -269,7 +270,7 @@ if (forcetk.Client === undefined) {
                     that.refreshAccessToken(function(oauthResponse) {
                         that.setSessionToken(oauthResponse.access_token, null,
                         oauthResponse.instance_url);
-                        that.ajax(path, callback, error, method, payload, true);
+                        that.apexrest(path, callback, error, method, payload, paramMap, true);
                     },
                     error);
                 } else {


### PR DESCRIPTION
I believe it's pretty common to set HTTP headers when using REST. I added a parameter to the apexrest function to pass in a map of header names to head values. What do you think?

Example:

forcetk.Client.apexrest('attach',
                function(msg){ alert('rest response'+msg); },//callback
                function(msg){ alert('err:'+msg.responseText); },//error
                'POST',//method
                e.target.result,//payload
                {upload_filename:"filename", upload_pid:"parentObjectID"},//paramMap
                true);//retry

Signed-off-by: Alex Berg chexxor@gmail.com
