### PR TITLE
Add in queryMore method to the forceTk toolkit

### DIFF
--- a/forcetk.js
+++ b/forcetk.js
@@ -431,7 +431,7 @@ if (forcetk.Client === undefined) {
         , callback, error);
     }
     
-	/*
+    /*
      * Queries the next set of records based on pagination.
      * <p>This should be used if performing a query that retrieves more than can be returned
      * in accordance with http://www.salesforce.com/us/developer/docs/api_rest/Content/dome_query.htm</p>


### PR DESCRIPTION
Calling forcetkClient.ajax doesn't quite work as ajax adds on 'services/data' to the request, which is already present from successResponse.nextRecordsUrl - and would otherwise result in an invalid url.

This simply removes that section, so a client can call 
forcetkClient.queryMore( successResponse.nextRecordsUrl, successHandler, failureHandler )
