### PR TITLE
Make ajax method compatible with nextRecordsUrl

### DIFF
--- a/forcetk.js
+++ b/forcetk.js
@@ -147,6 +147,9 @@ if (forcetk.Client === undefined) {
      */
     forcetk.Client.prototype.ajax = function(path, callback, error, method, payload, retry) {
         var that = this;
+        if (path.substring(0, 14) != '/services/data') {
+            path = '/services/data' + path;
+        }
         var url = this.instanceUrl + '/services/data' + path;
 
         $j.ajax({


### PR DESCRIPTION
The ajax call no longer prepends /services/data to paths that already
start with it.  This allows the ajax method to be used with the URL
contained in the nextRecordsUrl attribute of the result object passed to
the query method's success callback.

Here's an example:

``` javascript
forcetkClient.query('SELECT Id, Name FROM Account', handleResult, function() {});

function handleResult(result) {
    // do something with the result
    if (! result.done) {
        forcetkClient.ajax(result.nextRecordsUrl, handleResult, function() {});
    }
}
```
