### PR TITLE
Check http-prefixed content-* headers

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -234,7 +234,8 @@ if ( !$url ) {
       isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : 'GET' );
 
   // Pass on content, regardless of request method
-  if ( isset($_SERVER['CONTENT_LENGTH'] ) && $_SERVER['CONTENT_LENGTH'] > 0 ) {
+  if ( (isset($_SERVER['CONTENT_LENGTH'] ) && $_SERVER['CONTENT_LENGTH'] > 0) ||
+       (isset($_SERVER['HTTP_CONTENT_LENGTH'] ) && $_SERVER['HTTP_CONTENT_LENGTH'] > 0) ) {
     curl_setopt( $ch, CURLOPT_POSTFIELDS, file_get_contents("php://input") );
   }
 
@@ -257,9 +258,12 @@ if ( !$url ) {
     array_push($headers, "Authorization: ".$_SERVER[$authz_header] );
   }
   if ( isset($_SERVER['CONTENT_TYPE']) ) {
-	// Pass through the Content-Type header
-	array_push($headers, "Content-Type: ".$_SERVER['CONTENT_TYPE'] );
-  }	
+  // Pass through the Content-Type header
+    array_push($headers, "Content-Type: ".$_SERVER['CONTENT_TYPE'] );
+  } elseif ( isset($_SERVER['HTTP_CONTENT_TYPE']) ) {
+  // Pass through the Content-Type header
+    array_push($headers, "Content-Type: ".$_SERVER['HTTP_CONTENT_TYPE'] );
+  }
   if ( isset($_SERVER['HTTP_X_USER_AGENT']) ) {
 	// Pass through the X-User-Agent header
 	array_push($headers, "X-User-Agent: ".$_SERVER['HTTP_X_USER_AGENT'] );


### PR DESCRIPTION
The built-in web server in PHP 5.4 sets the Content-Length and Content-Type
headers in $_SERVER['HTTP_CONTENT_LENGTH'] and $_SERVER['HTTP_CONTENT_TYPE']
rather than $_SERVER['CONTENT_LENGTH'] and $_SERVER['CONTENT_TYPE'].
