### PR TITLE
Add support for cloudforce.com instances

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -169,8 +169,7 @@
 // Change these configuration options if needed, see above descriptions for info.
 $enable_jsonp    = false;
 $enable_native   = true;
-$valid_forcecom_url_regex = '/https:\/\/.*.salesforce.com/';
-$valid_databasecom_url_regex = '/https:\/\/.*database.com/';
+$valid_forcecom_url_regex = '/https:\/\/.*\.(salesforce|database|cloudforce)\.com/';
 
 
 $url_query_param = null; // 'url'
@@ -203,7 +202,7 @@ if ( !$url ) {
   $status['http_code'] = 400;
   $status['status_text'] = 'Bad Request';
   
-} else if ( !preg_match( $valid_forcecom_url_regex, $url ) && !preg_match( $valid_databasecom_url_regex, $url )) {
+} else if ( !preg_match( $valid_forcecom_url_regex, $url )) {
   
   // Passed url doesn't match $valid_url_regex.
   $contents = 'ERROR: invalid url';


### PR DESCRIPTION
Allow proxy to send requests to cloudforce.com instances in addition to
*.salesforce.com and *.database.com ones.
