### PR TITLE
Improve compatiblity of RemoteTK with ForceTK

### DIFF
--- a/RemoteTK.component
+++ b/RemoteTK.component
@@ -57,6 +57,12 @@ if (remotetk.Client === undefined) {
      */
     remotetk.Client = function(){
     }
+
+    /** NOOP: for compatibility with forcetk
+    */
+    remotetk.Client.prototype.setSessionToken = function() {}
+    remotetk.Client.prototype.setRefreshToken = function() {}
+    remotetk.Client.prototype.setUserAgentString = function() {}
         
     /*
      * Completely describes the individual metadata at all levels for the 

--- a/RemoteTKController.cls
+++ b/RemoteTKController.cls
@@ -45,6 +45,13 @@ public class RemoteTKController {
             field.put('type', descField.getType().name().toLowerCase());
             field.put('name', descField.getName());
             field.put('label', descField.getLabel());
+            List<String> references = new List<String>();
+            for (Schema.sObjectType t: descField.getReferenceTo()) {
+                references.add(t.getDescribe().getName());
+            }
+            if (!references.isEmpty()) {
+                field.put('referenceTo', references);
+            }
             
             fields.add(field);
         }
@@ -224,6 +231,8 @@ public class RemoteTKController {
         
         Map<String, Object> result = new Map<String, Object>();
         result.put('records', records);
+        result.put('totalSize', records.size());
+        result.put('done', true);
         
         return JSON.serialize(result);
     }


### PR DESCRIPTION
Changes to allow RemoteTK to be used as a drop-in replacement for ForceTK:
Add setSessionToken, setRefreshToken, and setUserAgentString noop functions.

Return referenceTo attribute with describe responses.

Return totalSize and done attributes with query responses.
