### PR TITLE
Handle Apex exceptions passed back to javascript remoting

### DIFF
--- a/RemoteTK.component
+++ b/RemoteTK.component
@@ -84,8 +84,15 @@ if (remotetk.Client === undefined) {
      */
     remotetk.Client.prototype.describe = function(objtype, callback, error) {
         var deferred = $.Deferred();
-        Visualforce.remoting.Manager.invokeAction('{!$RemoteAction.RemoteTKController.describe}', objtype, function(result){
-            handleResult(result, callback, error, false, deferred);
+        Visualforce.remoting.Manager.invokeAction('{!$RemoteAction.RemoteTKController.describe}', objtype, function(result, err) {
+            if (err.status) {
+                handleResult(result, callback, error, false, deferred);
+            } else {
+                if (typeof error === 'function') {
+                    error(err);
+                }
+                deferred.reject(err);
+            }
         }, {
             escape: false
         });
@@ -103,8 +110,15 @@ if (remotetk.Client === undefined) {
      */
     remotetk.Client.prototype.create = function(objtype, fields, callback, error) {
         var deferred = $.Deferred();
-        Visualforce.remoting.Manager.invokeAction('{!$RemoteAction.RemoteTKController.create}', objtype, JSON.stringify(fields), function(result){
-            handleResult(result, callback, error, false, deferred);
+        Visualforce.remoting.Manager.invokeAction('{!$RemoteAction.RemoteTKController.create}', objtype, JSON.stringify(fields), function(result, err) {
+            if (err.status) {
+                handleResult(result, callback, error, false, deferred);
+            } else {
+                if (typeof error === 'function') {
+                    error(err);
+                }
+                deferred.reject(err);
+            }
         }, {
             escape: false
         });
@@ -122,8 +136,15 @@ if (remotetk.Client === undefined) {
      */
     remotetk.Client.prototype.retrieve = function(objtype, id, fieldlist, callback, error) {
         var deferred = $.Deferred();
-        Visualforce.remoting.Manager.invokeAction('{!$RemoteAction.RemoteTKController.retrieve}', objtype, id, fieldlist, function(result){
-            handleResult(result, callback, error, false, deferred);
+        Visualforce.remoting.Manager.invokeAction('{!$RemoteAction.RemoteTKController.retrieve}', objtype, id, fieldlist, function(result, err) {
+            if (err.status) {
+                handleResult(result, callback, error, false, deferred);
+            } else {
+                if (typeof error === 'function') {
+                    error(err);
+                }
+                deferred.reject(err);
+            }
         }, {
             escape: false
         });
@@ -144,8 +165,15 @@ if (remotetk.Client === undefined) {
      */
     remotetk.Client.prototype.upsert = function(objtype, externalIdField, externalId, fields, callback, error) {
         var deferred = $.Deferred();
-        Visualforce.remoting.Manager.invokeAction('$RemoteAction.RemoteTKController.upser', objtype, externalIdField, externalId, JSON.stringify(fields), function(result){
-            handleResult(result, callback, error, true, deferred);
+        Visualforce.remoting.Manager.invokeAction('$RemoteAction.RemoteTKController.upser', objtype, externalIdField, externalId, JSON.stringify(fields), function(result, err) {
+            if (err.status) {
+                handleResult(result, callback, error, true, deferred);
+            } else {
+                if (typeof error === 'function') {
+                    error(err);
+                }
+                deferred.reject(err);
+            }
         }, {
             escape: false
         });
@@ -164,8 +192,15 @@ if (remotetk.Client === undefined) {
      */
     remotetk.Client.prototype.update = function(objtype, id, fields, callback, error) {
         var deferred = $.Deferred();
-        Visualforce.remoting.Manager.invokeAction('{!$RemoteAction.RemoteTKController.updat}', objtype, id, JSON.stringify(fields), function(result){
-            handleResult(result, callback, error, true, deferred);
+        Visualforce.remoting.Manager.invokeAction('{!$RemoteAction.RemoteTKController.updat}', objtype, id, JSON.stringify(fields), function(result, err) {
+            if (err.status) {
+                handleResult(result, callback, error, true, deferred);
+            } else {
+                if (typeof error === 'function') {
+                    error(err);
+                }
+                deferred.reject(err);
+            }
         }, {
             escape: false
         });
@@ -182,8 +217,15 @@ if (remotetk.Client === undefined) {
      */
     remotetk.Client.prototype.del = function(objtype, id, callback, error) {
         var deferred = $.Deferred();
-        Visualforce.remoting.Manager.invokeAction('{!$RemoteAction.RemoteTKController.del}', objtype, id, function(result){
-            handleResult(result, callback, error, true, deferred);
+        Visualforce.remoting.Manager.invokeAction('{!$RemoteAction.RemoteTKController.del}', objtype, id, function(result, err) {
+            if (err.status) {
+                handleResult(result, callback, error, true, deferred);
+            } else {
+                if (typeof error === 'function') {
+                    error(err);
+                }
+                deferred.reject(err);
+            }
         }, {
             escape: false
         });
@@ -199,8 +241,15 @@ if (remotetk.Client === undefined) {
      */
     remotetk.Client.prototype.query = function(soql, callback, error) {
         var deferred = $.Deferred();
-        Visualforce.remoting.Manager.invokeAction('{!$RemoteAction.RemoteTKController.query}', soql, function(result){
-            handleResult(result, callback, error, false, deferred);
+        Visualforce.remoting.Manager.invokeAction('{!$RemoteAction.RemoteTKController.query}', soql, function(result, err) {
+            if (err.status) {
+                handleResult(result, callback, error, false, deferred);
+            } else {
+                if (typeof error === 'function') {
+                    error(err);
+                }
+                deferred.reject(err);
+            }
         }, {
             escape: false
         });
@@ -216,8 +265,15 @@ if (remotetk.Client === undefined) {
      */
     remotetk.Client.prototype.search = function(sosl, callback, error) {
         var deferred = $.Deferred();
-        Visualforce.remoting.Manager.invokeAction('{!$RemoteAction.RemoteTKController.search}', sosl, function(result){
-            handleResult(result, callback, error, false, deferred);
+        Visualforce.remoting.Manager.invokeAction('{!$RemoteAction.RemoteTKController.search}', sosl, function(result, err) {
+            if (err.status) {
+                handleResult(result, callback, error, false, deferred);
+            } else {
+                if (typeof error === 'function') {
+                    error(err);
+                }
+                deferred.reject(err);
+            }
         }, {
             escape: false
         });


### PR DESCRIPTION
If an uncaught exception occurs in RemoteTKController, pass the error
returned by the javascript remoting call to the error callback.

_My change from #31 is included as well._
