### PR TITLE
Include createable/updateable flags with field descriptions

### DIFF
--- a/RemoteTKController.cls
+++ b/RemoteTKController.cls
@@ -106,6 +106,8 @@ public class RemoteTKController {
             field.put('type', descField.getType().name().toLowerCase());
             field.put('name', descField.getName());
             field.put('label', descField.getLabel());
+            field.put('updateable', descField.isUpdateable());
+            field.put('createable', descField.isCreateable());
             List<String> references = new List<String>();
             for (Schema.sObjectType t: descField.getReferenceTo()) {
                 references.add(t.getDescribe().getName());


### PR DESCRIPTION
Include the createable/updateable flags with the fields returned by the
describe call so fields that should not be sent to create/update/upsert
calls can be filtered out.
