### PR TITLE
Convert date empty string to null

### DIFF
--- a/RemoteTKController.cls
+++ b/RemoteTKController.cls
@@ -63,7 +63,7 @@ public class RemoteTKController {
                     String svalue = (String)value;
                     
                     if (valueType == Schema.DisplayType.Date) {
-                        obj.put(key, Date.valueOf(svalue));
+                        obj.put(key, svalue == '' ? null : Date.valueOf(svalue));
                     } else if (valueType == Schema.DisplayType.Percent ||
                            valueType == Schema.DisplayType.Currency) {
                         obj.put(key, svalue == '' ? null : Decimal.valueOf(svalue));


### PR DESCRIPTION
Creating or updating with an empty string for a date field should be possible. The empty string should be interpreted as null for date fields as is already the case for other types.
