### PR TITLE
escape method has been deprecated

### DIFF
--- a/forcetk.js
+++ b/forcetk.js
@@ -445,7 +445,7 @@ if (forcetk.Client === undefined) {
      * @param [error=null] function to which jqXHR will be passed in case of error
      */
     forcetk.Client.prototype.query = function(soql, callback, error) {
-        return this.ajax('/' + this.apiVersion + '/query?q=' + escape(soql)
+        return this.ajax('/' + this.apiVersion + '/query?q=' + encodeURI(soql)
         , callback, error);
     }
     
@@ -481,7 +481,7 @@ if (forcetk.Client === undefined) {
      * @param [error=null] function to which jqXHR will be passed in case of error
      */
     forcetk.Client.prototype.search = function(sosl, callback, error) {
-        return this.ajax('/' + this.apiVersion + '/search?q=' + escape(sosl)
+        return this.ajax('/' + this.apiVersion + '/search?q=' + encodeURI(sosl)
         , callback, error);
     }
 }

--- a/forcetk.js
+++ b/forcetk.js
@@ -388,7 +388,7 @@ if (forcetk.Client === undefined) {
             fieldlist = null;
         }
         var fields = fieldlist ? '?fields=' + fieldlist : '';
-        this.ajax('/' + this.apiVersion + '/sobjects/' + objtype + '/' + id
+        return this.ajax('/' + this.apiVersion + '/sobjects/' + objtype + '/' + id
         + fields, callback, error);
     }
 


### PR DESCRIPTION
escape method has been deprecated since ECMAScript v3.
and cannot work fine at multibyte.

add return to retrieve ajax.
