### PR TITLE
removing extra new line that would corrupt ms office file attachments

### DIFF
--- a/forcetk.js
+++ b/forcetk.js
@@ -286,7 +286,7 @@ if (forcetk.Client === undefined) {
             + "Content-Disposition: form-data; name=\"" + payloadField 
               + "\"; filename=\"" + filename + "\"\n\n",
             payload,
-            "\n\n" 
+            "\n" 
             + "--boundary_" + boundary + "--"
         ], {type : 'multipart/form-data; boundary=\"boundary_' + boundary + '\"'});
         


### PR DESCRIPTION
Tools like Adobe reader and Text editors ignore the extra additional empty line at the end but MS office complains that the file is corrupt