### PR TITLE
adding content type for attachments for IE 11 support

### DIFF
--- a/forcetk.js
+++ b/forcetk.js
@@ -296,6 +296,7 @@ if (forcetk.Client === undefined) {
         request.setRequestHeader('Accept', 'application/json');
         request.setRequestHeader(this.authzHeader, "Bearer " + this.sessionId);
         request.setRequestHeader('X-User-Agent', 'salesforce-toolkit-rest-javascript/' + this.apiVersion);
+        request.setRequestHeader('Content-Type', 'multipart/form-data; boundary=\"boundary_' + boundary + '\"');
         if (this.proxyUrl !== null && ! this.visualforce) {
             request.setRequestHeader('SalesforceProxy-Endpoint', url);
         }


### PR DESCRIPTION
Firefox and Chrome browsers derive the "Content-Type" header parameter from the attachment blob, but IE doesn't.