### PR TITLE
Fixing syntax error in app.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -156,7 +156,7 @@
      && !response.Website.startsWith('http://')) {
          response.Website = 'http://'+response.Website;
      }
-     $dialog.TrimPath.processDOMTemplate("detail_jst"
+     $dialog.html(TrimPath.processDOMTemplate("detail_jst"
          ,response));
      $dialog.find('#industry').click(function(e) {
          e.preventDefault();


### PR DESCRIPTION
Change code in detailCallback() inside app.js to fix missing parenthesis syntax error on setting dialog html.