### PR TITLE
Fix IE incorrect parameter errors on VF pages

### DIFF
--- a/forcetk.js
+++ b/forcetk.js
@@ -81,6 +81,17 @@ if (forcetk.Client === undefined) {
     };
 
     /**
+     * Creates an AJAX request object. Can be overridden for particular implementations.
+     */
+    forcetk.Client.prototype.getXHR = function () {
+        if (window && window.Sarissa && window.Sarissa.originalXMLHttpRequest) {
+            return new window.Sarissa.originalXMLHttpRequest();
+        } else {
+            return new XMLHttpRequest();
+        }
+    };
+
+    /**
      * Set a refresh token in the client.
      * @param refreshToken an OAuth refresh token
      */
@@ -211,7 +222,7 @@ if (forcetk.Client === undefined) {
         'use strict';
         var that = this,
             url = (this.visualforce ? '' : this.instanceUrl) + path,
-            request = new XMLHttpRequest();
+            request = this.getXHR();
 
         request.open("GET", (this.proxyUrl !== null && !this.visualforce) ? this.proxyUrl : url, true);
         request.responseType = "arraybuffer";
@@ -293,7 +304,7 @@ if (forcetk.Client === undefined) {
                 "\n\n"
                     + "--boundary_" + boundary + "--"
             ], {type : 'multipart/form-data; boundary=\"boundary_' + boundary + '\"'}),
-            request = new XMLHttpRequest();
+            request = this.getXHR();
 
         request.open("POST", (this.proxyUrl !== null && !this.visualforce) ? this.proxyUrl : url, this.asyncAjax);
 


### PR DESCRIPTION
Extracted XMLHttpRequest object instantiation into a separate method.
Added a test and workaround for Visualforce's Sarissa library XMLHttpRequest constructor masking.