### PR TITLE
Update forcetk.js

### DIFF
--- a/forcetk.js
+++ b/forcetk.js
@@ -290,7 +290,7 @@ if (forcetk.Client === undefined) {
                     + "Content-Disposition: form-data; name=\"" + payloadField
                     + "\"; filename=\"" + filename + "\"\n\n",
                 payload,
-                "\n\n"
+                "\n"
                     + "--boundary_" + boundary + "--"
             ], {type : 'multipart/form-data; boundary=\"boundary_' + boundary + '\"'}),
             request = new XMLHttpRequest();


### PR DESCRIPTION
Extra line break creates issue with Microsoft office files (pptx, docx) etc.
File downloaded from Salesforce give error, file corrupted.